### PR TITLE
Adding docker image deployment option

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,1 @@
+{"image":"mcr.microsoft.com/devcontainers/universal:2"}

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.env
+.env.*
+*.db
+*.sqlite3
+*.log
+media/
+# Docker
+*.dockerfile
+Dockerfile
+# VSCode
+.vscode/
+# OS
+.DS_Store
+Thumbs.db

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,7 @@
+# Build and run the Fabric Admin MCP server in Docker
+# Usage:
+#   docker build -t fabric-admin-mcp .
+#   docker run -p 8000:8000 --env AZURE_CLIENT_ID=... --env AZURE_TENANT_ID=... --env AZURE_CLIENT_SECRET=... fabric-admin-mcp
+# Or use docker-compose:
+#   docker-compose up --build
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy requirements and install Python dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Expose MCP server port
+EXPOSE 8000
+
+# Environment variables for Azure authentication should be provided at runtime using --env-file or Docker Compose
+
+# Start the MCP server
+CMD ["python", "server.py"]

--- a/README.md
+++ b/README.md
@@ -40,10 +40,27 @@ This example demonstrates how the MCP tools are exposed and can be accessed for 
    ```sh
    python server.py
    ```
-   The server will start at [http://127.0.0.1:8000/mcp/](http://127.0.0.1:8000/mcp/).
+
+## Running the MCP Server in Docker (locally)
+
+1. **Prepare your environment variables:**
+   - Copy `env.example` to `.env` and fill in your Azure credentials.
+
+2. **Build the Docker image:**
+   ```bash
+   docker build -t fabric-admin-mcp .
+   ```
+
+3. **Run the Docker container:**
+   ```bash
+   docker run --env-file .env -p 8000:8000 fabric-admin-mcp
+   ```
+
+4. **Access the MCP server:**
+   - The server will start at [http://127.0.0.1:8000/mcp/](http://127.0.0.1:8000/mcp/).
 
 4. **Test with VS Code as a Client:**
-   - Open the Command Palette (`Ctrl+Shift+P`), search for "MCP: Connect to Server", and enter `http://127.0.0.1:8000/mcp/`.
+   - Open the Command Palette (`Ctrl+Shift+P`), search for "MCP: Connect to Server", and enter `http://127.0.0.1:8000/mcp/` (change the address if running it remotely).
    - You can now use MCP tools exposed by this server directly from VS Code using Agent Mode.
 
 ## 📦 Requirements

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+# Fabric Admin MCP Server Docker Compose
+version: '3.8'
+services:
+  fabric-admin-mcp:
+    build: .
+    ports:
+      - "8000:8000"
+    environment:
+      - AZURE_CLIENT_ID=${AZURE_CLIENT_ID}
+      - AZURE_TENANT_ID=${AZURE_TENANT_ID}
+      - AZURE_CLIENT_SECRET=${AZURE_CLIENT_SECRET}
+    restart: unless-stopped

--- a/env.example
+++ b/env.example
@@ -1,0 +1,4 @@
+# Azure Service Principal Authentication
+AZURE_TENANT_ID=<your-tenant-id>
+AZURE_CLIENT_ID=<your-client-id>
+AZURE_CLIENT_SECRET=<your-client-secret>


### PR DESCRIPTION
This pull request introduces Docker support for the Fabric Admin MCP server, including necessary configuration files, instructions, and environment setup. The most important changes involve adding a Dockerfile, a `docker-compose.yml` file, and updates to documentation to guide users on building and running the server in Docker.

### Docker support additions:

* **Dockerfile**: Added a Dockerfile to containerize the MCP server, including system dependencies, Python requirements, and application code. The server is exposed on port 8000.
* **`docker-compose.yml`**: Introduced a Docker Compose configuration to simplify running the MCP server with environment variables for Azure authentication.

### Documentation updates:

* **`DOCKER.md`**: Created a new file with instructions on building and running the MCP server in Docker, including usage of Docker Compose.
* **`README.md`**: Updated the README to include steps for running the MCP server locally in Docker, along with environment setup and access instructions.

### Environment setup:

* **`env.example`**: Added an example environment file to guide users in providing Azure authentication credentials.

### Miscellaneous:

* **`.dockerignore`**: Added a `.dockerignore` file to exclude unnecessary files from the Docker build context.
* **`.devcontainer/devcontainer.json`**: Updated the devcontainer configuration to use a universal base image.